### PR TITLE
Update method for selecting correct takeCount

### DIFF
--- a/DataTables.NetStandard/PagedList.cs
+++ b/DataTables.NetStandard/PagedList.cs
@@ -43,7 +43,7 @@ namespace DataTables.NetStandard
             PagesCount = PageSize <= 0 ? 1 : (int)Math.Ceiling((double)(TotalCount / PageSize));
 
             int skipCount = Math.Abs((PageNumber - 1) * PageSize);
-            int takeCount = PageSize <= 0 ? TotalCount : PageSize;
+            int takeCount = PageSize <= 0 ? int.MaxValue : PageSize;
 
             var result = queryable.Skip(skipCount).Take(takeCount).ToList();
 


### PR DESCRIPTION
If `PageSize <= 0` and `TotalCount` is 0, it will result to a query `Skip(0).Take(0)`. This statement however result in an exception in EFCore: `The number of rows provided for a FETCH clause must be greater then zero.`