### PR TITLE
Add support for custom order expression for columns

### DIFF
--- a/DataTables.NetStandard.Sample/DataTables/PersonDataTable.cs
+++ b/DataTables.NetStandard.Sample/DataTables/PersonDataTable.cs
@@ -76,7 +76,8 @@ namespace DataTables.NetStandard.Sample.DataTables
                     PrivatePropertyName = $"{nameof(Person.Location)}.{nameof(Location.Street)}",
                     IsOrderable = true,
                     IsSearchable = true,
-                    SearchPredicate = (p, s) => (p.Location.Street + " " + p.Location.HouseNumber).ToLower().Contains(s.ToLower())
+                    SearchPredicate = (p, s) => (p.Location.Street + " " + p.Location.HouseNumber).ToLower().Contains(s.ToLower()),
+                    ColumnOrderingExpression = (p) => (p.Location.Street + " " + (p.Location.HouseNumber ?? "")).Trim().ToLower()
                 },
                 new DataTablesColumn<Person, PersonViewModel>
                 {

--- a/DataTables.NetStandard/DataTablesColumn.cs
+++ b/DataTables.NetStandard/DataTablesColumn.cs
@@ -113,6 +113,12 @@ namespace DataTables.NetStandard
         public Expression<Func<TEntity, object>> ColumnOrderingProperty { get; set; }
 
         /// <summary>
+        /// Optional expression that specifies an expression which should be used if ordering by the column is required. 
+        /// If no expression provided, the same property will be used for sorting as specified by <see cref="PrivatePropertyName"/> value.
+        /// </summary>
+        public Expression<Func<TEntity, object>> ColumnOrderingExpression { get; set; }
+
+        /// <summary>
         /// Optional predicate expression that will be used to search by the searchable column when 
         /// <see cref="DataTablesRequest{TEntity, TEntityViewModel}.GlobalSearchValue"/> is specified.
         /// If no predicate is provided, the <see cref="SearchPredicate"/> or <see cref="string.Contains(string)"/> method is used by default.

--- a/DataTables.NetStandard/Extensions/DataTablesQueryableExtensions.cs
+++ b/DataTables.NetStandard/Extensions/DataTablesQueryableExtensions.cs
@@ -157,11 +157,18 @@ namespace DataTables.NetStandard.Extensions
 
             foreach (var c in columns)
             {
-                var propertyName = c.ColumnOrderingProperty != null
-                    ? c.ColumnOrderingProperty.GetPropertyPath() 
-                    : c.PrivatePropertyName;
+                if (c.ColumnOrderingExpression != null)
+                {
+                    queryable = (IDataTablesQueryable<TEntity, TEntityViewModel>)queryable.OrderBy(c.ColumnOrderingExpression, c.OrderingDirection, alreadyOrdered);
+                }
+                else
+                {
+                    var propertyName = c.ColumnOrderingProperty != null
+                        ? c.ColumnOrderingProperty.GetPropertyPath()
+                        : c.PrivatePropertyName;
 
-                queryable = (IDataTablesQueryable<TEntity, TEntityViewModel>)queryable.OrderBy(propertyName, c.OrderingDirection, c.OrderingCaseInsensitive, alreadyOrdered);
+                    queryable = (IDataTablesQueryable<TEntity, TEntityViewModel>)queryable.OrderBy(propertyName, c.OrderingDirection, c.OrderingCaseInsensitive, alreadyOrdered);
+                }
 
                 alreadyOrdered = true;
             }

--- a/DataTables.NetStandard/Extensions/QueryableExtensions.cs
+++ b/DataTables.NetStandard/Extensions/QueryableExtensions.cs
@@ -125,6 +125,27 @@ namespace DataTables.NetStandard.Extensions
         }
 
         /// <summary>
+        /// Orders the given <see cref="IQueryable{TEntity}"/> by the given <paramref name="propertyName"/>.
+        /// The method will consider the given <paramref name="direction"/> and if the order should be applied
+        /// with <paramref name="caseInsensitive"/> logic.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the entity.</typeparam>
+        /// <param name="query">The query.</param>
+        /// <param name="orderExpression">Name of the property.</param>
+        /// <param name="direction">The direction.</param>
+        /// <param name="alreadyOrdered">if set to <c>true</c>, follow-up order logic will be used.</param>
+        internal static IQueryable<TEntity> OrderBy<TEntity>(this IQueryable<TEntity> query, 
+            Expression<Func<TEntity, object>> orderExpression, ListSortDirection direction, bool alreadyOrdered)
+        {
+            var methodName = GetOrderMethodName(direction, alreadyOrdered);
+            var typeArguments = new Type[] { typeof(TEntity), typeof(object) };
+
+            var resultExpr = Expression.Call(typeof(Queryable), methodName, typeArguments, query.Expression, orderExpression);
+
+            return query.Provider.CreateQuery<TEntity>(resultExpr);
+        }
+
+        /// <summary>
         /// Gets the name of the order method matching the given requirements.
         /// </summary>
         /// <param name="direction">The order direction.</param>

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ public override IList<DataTablesColumn<Person, PersonViewModel>> Columns()
             GlobalSearchPredicate = (p, s) => p.Id.ToString().Contains(s),
             ColumnSearchPredicate = (p, s) => p.Id.ToString().Contains(s),
             ColumnOrderingProperty = (p) => p.Id,
+            ColumnOrderingExpression = (p) => (p.Street + " " + (p.HouseNumber ?? "")).Trim().ToLower(),
             AdditionalOptions = new Dictionary<string, dynamic>
             {
                 { "visible", false },
@@ -346,6 +347,7 @@ Column                      | Mandatory | Default                         | Func
 `GlobalSearchPredicate`     | No        | `SearchPredicate` or its default | An expression that is used to search the column when a global search value is set. The expression receives the query model and the global search value as parameters. _Note: You should make sure the expression can be translated by Linq to SQL, otherwise it may be evaluated in-memory._
 `ColumnSearchPredicate`     | No        | `SearchPredicate` or its default | An expression that is used to search the column when a column search value is set. The expression receives the query model and the column search value as parameters. _Note: You should make sure the expression can be translated by Linq to SQL, otherwise it may be evaluated in-memory._
 `ColumnOrderingProperty`    | No        | `PrivatePropertyName`           | An expression that selects a column of the query model to order the results by. Can be a nested property.
+`ColumnOrderingExpression`  | No        | `PrivatePropertyName`           | An expression that selects the data of the query model to order the results by. Can return complex expressions. Takes precedence over the `ColumnOrderingProperty`.
 `OrderingIndex`             | No        | `-1` (_ordering disabled_)      | A non-negative index for the ordering of this column. This option basically contains an ordering priority where columns with lower indexes will get ordered first. This is the default column ordering applied to a table on first load. If `stateSave` is enabled, the saved state will override this setting.
 `OrderingDirection`         | No        | `ListSortDirection.Ascending`   | The default sort direction. This option only takes effect if `OrderingIndex` is set.
 `AdditionalOptions`         | No        | empty `Dictionary`              | A dictionary that can be used to pass additional columns options which are serialized as part of the generated DataTable script. The additional options are serialized as they are, without changing dictionary keys from _PascalCase_ to _camelCase_.


### PR DESCRIPTION
This PR solves the feature request #5. A new property `ColumnOrderingExpression` has been added to the `DataTablesColumn` type. It has precedence over existing order configuration and supports pretty much ordering by any data.

The change is fully backwards compatible.