### PR TITLE
Allow dynamic creation of search predicates using provider expressions

### DIFF
--- a/DataTables.NetStandard.Sample/DataTables/PersonDataTable.cs
+++ b/DataTables.NetStandard.Sample/DataTables/PersonDataTable.cs
@@ -28,7 +28,21 @@ namespace DataTables.NetStandard.Sample.DataTables
                     PrivatePropertyName = nameof(Person.Id),
                     IsOrderable = true,
                     IsSearchable = true,
-                    SearchRegex = true
+                    SearchPredicate = (p, s) => false,                  // The fallback predicate will never match, but since we declared a provider, it is not used anyway.
+                    SearchPredicateProvider = (s) => (p, s) => true,    // The provider will return a predicate matching all entities (used for global search). This is just for illustration, it makes no sense.
+                    ColumnSearchPredicateProvider = (s) =>              // The column provider will return a predicate matching entities in a numeric range if the search term is properly formatted.
+                    {
+                        var minMax = s.Split("-delim-", System.StringSplitOptions.RemoveEmptyEntries);
+                        if (minMax.Length >= 2)
+                        {
+                            var min = long.Parse(minMax[0]);
+                            var max = long.Parse(minMax[1]);
+
+                            return (p, s) => p.Id >= min && p.Id <= max;
+                        }
+
+                        return (p, s) => false;
+                    }
                 },
                 new DataTablesColumn<Person, PersonViewModel>
                 {

--- a/DataTables.NetStandard/DataTablesColumn.cs
+++ b/DataTables.NetStandard/DataTablesColumn.cs
@@ -101,10 +101,40 @@ namespace DataTables.NetStandard
         public Expression<Func<TEntity, string, bool>> SearchPredicate { get; set; }
 
         /// <summary>
+        /// Optional search predicate provider. Can be used instead of <see cref="SearchPredicate"/>. Is being invoked with the
+        /// search term entered by the user, but before the query is passed to the database or similar.
+        /// The search predicate produced by this method takes precedence over the defined <see cref="SearchPredicate"/> .
+        /// </summary>
+        public Func<string, Expression<Func<TEntity, string, bool>>> SearchPredicateProvider { get; set; }
+
+        /// <summary>
         /// Optional predicate expression that will be used to search by the searchable column when <see cref="SearchValue"/> is specified.
         /// If no predicate is provided, the <see cref="SearchPredicate"/> or <see cref="string.Contains(string)"/> method is used by default.
         /// </summary>
         public Expression<Func<TEntity, string, bool>> ColumnSearchPredicate { get; set; }
+
+        /// <summary>
+        /// Optional column search predicate provider. Can be used instead of <see cref="ColumnSearchPredicate"/>. Is being invoked with the 
+        /// search term entered by the user, but before the query is passed to the database or similar.
+        /// The search predicate produced by this method takes precedence over the defined <see cref="ColumnSearchPredicate"/>,
+        /// <see cref="SearchPredicate"/> and the search predicate produced by <see cref="SearchPredicateProvider"/>.
+        /// </summary>
+        public Func<string, Expression<Func<TEntity, string, bool>>> ColumnSearchPredicateProvider { get; set; }
+
+        /// <summary>
+        /// Optional predicate expression that will be used to search by the searchable column when 
+        /// <see cref="DataTablesRequest{TEntity, TEntityViewModel}.GlobalSearchValue"/> is specified.
+        /// If no predicate is provided, the <see cref="SearchPredicate"/> or <see cref="string.Contains(string)"/> method is used by default.
+        /// </summary>
+        public Expression<Func<TEntity, string, bool>> GlobalSearchPredicate { get; set; }
+
+        /// <summary>
+        /// Optional column search predicate provider. Can be used instead of <see cref="GlobalSearchPredicate"/>. Is being invoked with the 
+        /// search term entered by the user, but before the query is passed to the database or similar.
+        /// The search predicate produced by this method takes precedence over the defined <see cref="GlobalSearchPredicate"/>,
+        /// <see cref="SearchPredicate"/> and the search predicate produced by <see cref="SearchPredicateProvider"/>.
+        /// </summary>
+        public Func<string, Expression<Func<TEntity, string, bool>>> GlobalSarchPredicateProvider { get; set; }
 
         /// <summary>
         /// Optional expression that specifies the different property which should be used if ordering by the column is required. 
@@ -117,13 +147,6 @@ namespace DataTables.NetStandard
         /// If no expression provided, the same property will be used for sorting as specified by <see cref="PrivatePropertyName"/> value.
         /// </summary>
         public Expression<Func<TEntity, object>> ColumnOrderingExpression { get; set; }
-
-        /// <summary>
-        /// Optional predicate expression that will be used to search by the searchable column when 
-        /// <see cref="DataTablesRequest{TEntity, TEntityViewModel}.GlobalSearchValue"/> is specified.
-        /// If no predicate is provided, the <see cref="SearchPredicate"/> or <see cref="string.Contains(string)"/> method is used by default.
-        /// </summary>
-        public Expression<Func<TEntity, string, bool>> GlobalSearchPredicate { get; set; }
 
         /// <summary>
         /// A dictionary of additional options that should be passed to the DataTables script for this column.

--- a/DataTables.NetStandard/Extensions/DataTablesQueryableExtensions.cs
+++ b/DataTables.NetStandard/Extensions/DataTablesQueryableExtensions.cs
@@ -53,9 +53,14 @@ namespace DataTables.NetStandard.Extensions
 
                     foreach (var c in columns)
                     {
+                        var globalSearchPredicateByProvider = c.GlobalSarchPredicateProvider != null ? c.GlobalSarchPredicateProvider(globalSearchValue) : null;
+                        var searchPredicateByProvider = globalSearchPredicateByProvider == null && c.SearchPredicateProvider != null
+                            ? c.SearchPredicateProvider(globalSearchValue)
+                            : null;
+
                         Expression<Func<TEntity, bool>> expression;
 
-                        var searchPredicate = c.GlobalSearchPredicate ?? c.SearchPredicate;
+                        var searchPredicate = globalSearchPredicateByProvider ?? searchPredicateByProvider ?? c.GlobalSearchPredicate ?? c.SearchPredicate;
                         if (searchPredicate != null)
                         {
                             var expr = searchPredicate;
@@ -80,7 +85,10 @@ namespace DataTables.NetStandard.Extensions
                             : predicate.Or(expression);
                     }
 
-                    queryable = (IDataTablesQueryable<TEntity, TEntityViewModel>)queryable.Where(predicate);
+                    if (predicate != null)
+                    {
+                        queryable = (IDataTablesQueryable<TEntity, TEntityViewModel>)queryable.Where(predicate);
+                    }
                 }
             }
 
@@ -106,9 +114,14 @@ namespace DataTables.NetStandard.Extensions
 
                 foreach (var c in columns)
                 {
+                    var columnSearchPredicateByProvider = c.ColumnSearchPredicateProvider != null ? c.ColumnSearchPredicateProvider(c.SearchValue) : null;
+                    var searchPredicateByProvider = columnSearchPredicateByProvider == null && c.SearchPredicateProvider != null
+                        ? c.SearchPredicateProvider(c.SearchValue)
+                        : null;
+
                     Expression<Func<TEntity, bool>> expression;
 
-                    var searchPredicate = c.ColumnSearchPredicate ?? c.SearchPredicate;
+                    var searchPredicate = columnSearchPredicateByProvider ?? searchPredicateByProvider ?? c.ColumnSearchPredicate ?? c.SearchPredicate;
                     if (searchPredicate != null)
                     {
                         var expr = searchPredicate;
@@ -134,7 +147,10 @@ namespace DataTables.NetStandard.Extensions
                         : predicate.And(expression);
                 }
 
-                queryable = (IDataTablesQueryable<TEntity, TEntityViewModel>)queryable.Where(predicate);
+                if (predicate != null)
+                {
+                    queryable = (IDataTablesQueryable<TEntity, TEntityViewModel>)queryable.Where(predicate);
+                }
             }
 
             return queryable;


### PR DESCRIPTION
This PR introduces three new properties on the `DataTablesColumn` class: 
- `SearchPredicateProvider` for `SearchPredicate`
- `ColumnSearchPredicateProvider` for `ColumnSearchPredicate`
- `GlobalSearchPredicateProvider` for `GlobalSearchPredicate`

Each of them can be used to create the respective search predicate dynamically using the search term as input. This is for example useful when receiving search input which needs to be transformed (e.g. tokenized, split, normalized, ...) before it can be used within the search predicate.

An example, as written in the README, which splits the search input to perform numeric range search, would be:
```cs
ColumnSearchPredicateProvider = (s) =>
{
    var minMax = s.Split("-delim-", System.StringSplitOptions.RemoveEmptyEntries);
    if (minMax.Length >= 2)
    {
        var min = long.Parse(minMax[0]);
        var max = long.Parse(minMax[1]);

        return (p, s) => p.Id >= min && p.Id <= max;
    }

    return (p, s) => false;
}
```