### PR TITLE
Support EFCore6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,22 @@
 version: 2
+
 updates:
-- package-ecosystem: nuget
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "05:00"
+      timezone: "Europe/Vienna"
+    labels:
+      - "nuget dependencies"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Vienna"
+    labels:
+      - "github actions"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,32 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: Test dotnet ${{ matrix.dotnet-version }}
+
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        dotnet-version: ['6.0.x']
+
     steps:
-    - uses: actions/checkout@v1
-    - name: Setup .NET Core Build Environment
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    - name: Build package
-      run: dotnet build --configuration Release
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Build package
+        run: dotnet build --configuration 'Release'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,18 +8,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v1
-      - name: Setup .NET Core Build Environment
-        uses: actions/setup-dotnet@v1
+      - uses: actions/checkout@v3
         with:
-          dotnet-version: '3.1.x'
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+
       - name: Build packages
-        run: dotnet build --configuration Release
+        run: dotnet build --configuration 'Release'
+
       - name: Pack NuGet packages
-        run: dotnet pack -c Release -o out
+        run: dotnet pack --configuration 'Release' --output 'out'
+
       - name: Push NuGet packages to nuget.org
-        run: dotnet nuget push **/*.nupkg
-               --api-key ${{ secrets.NUGET_API_KEY }}
-               --source https://api.nuget.org/v3/index.json
-               --skip-duplicate
+        run: dotnet nuget push **/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/DataTables.NetStandard.Sample/DataTables.NetStandard.Sample.csproj
+++ b/DataTables.NetStandard.Sample/DataTables.NetStandard.Sample.csproj
@@ -1,15 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.0" />
+    <PackageReference Include="AutoMapper" Version="11.0.1" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="DataTables.NetStandard.TemplateMapper" Version="1.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.6" />
   </ItemGroup>
 

--- a/DataTables.NetStandard.Sample/DataTables/BaseDataTable.cs
+++ b/DataTables.NetStandard.Sample/DataTables/BaseDataTable.cs
@@ -1,7 +1,7 @@
-﻿using AutoMapper;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using AutoMapper;
 
 namespace DataTables.NetStandard.Sample.DataTables
 {

--- a/DataTables.NetStandard.Sample/DataTables/PersonDataTable.cs
+++ b/DataTables.NetStandard.Sample/DataTables/PersonDataTable.cs
@@ -1,9 +1,9 @@
-﻿using AutoMapper;
+﻿using System.Collections.Generic;
+using System.Linq;
+using AutoMapper;
 using DataTables.NetStandard.Sample.DataTables.ViewModels;
 using DataTables.NetStandard.Sample.Models;
 using Microsoft.EntityFrameworkCore;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace DataTables.NetStandard.Sample.DataTables
 {

--- a/DataTables.NetStandard.Sample/Migrations/20190215192458_RenameUserToPerson.cs
+++ b/DataTables.NetStandard.Sample/Migrations/20190215192458_RenameUserToPerson.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace DataTables.NetStandard.Sample.Migrations
 {

--- a/DataTables.NetStandard.Sample/Models/ErrorViewModel.cs
+++ b/DataTables.NetStandard.Sample/Models/ErrorViewModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace DataTables.NetStandard.Sample.Models
 {
     public class ErrorViewModel

--- a/DataTables.NetStandard/Abstract/IPagedList.cs
+++ b/DataTables.NetStandard/Abstract/IPagedList.cs
@@ -3,27 +3,27 @@
 namespace DataTables.NetStandard.Abstract
 {
     /// <summary>
-    /// Describes single page of data extracted from the <see cref="IDataTablesQueryable{TEntity}"/> 
+    /// Describes a single page of data extracted from the <see cref="IDataTablesQueryable{TEntity}"/>.
     /// </summary>
     public interface IPagedList : IList
     {
         /// <summary>
-        /// Total items count in the whole collection 
+        /// Total items count in the whole collection.
         /// </summary>
         int TotalCount { get; }
 
         /// <summary>
-        /// Count of items per page
+        /// Count of items per page.
         /// </summary>
         int PageSize { get; }
 
         /// <summary>
-        /// 1-bazed page number
+        /// The number of the current page, starting from 1.
         /// </summary>
         int PageNumber { get; }
 
         /// <summary>
-        /// Total number of pages in the whole collection
+        /// Total number of pages in the whole collection.
         /// </summary>
         int PagesCount { get; }
     }

--- a/DataTables.NetStandard/DataTable.cs
+++ b/DataTables.NetStandard/DataTable.cs
@@ -44,7 +44,6 @@ namespace DataTables.NetStandard
         /// <summary>
         /// A mapping function used to map query models to view models.
         /// </summary>
-        /// <returns></returns>
         public abstract Expression<Func<TEntity, TEntityViewModel>> MappingFunction();
 
         /// <summary>
@@ -95,7 +94,6 @@ namespace DataTables.NetStandard
         /// Renders the results based on the given <see cref="DataTablesRequest{TEntity, TEntityViewModel}"/>.
         /// </summary>
         /// <param name="request">The request.</param>
-        /// <returns></returns>
         public virtual IPagedList<TEntityViewModel> RenderResults(DataTablesRequest<TEntity, TEntityViewModel> request)
         {
             Configure();
@@ -220,7 +218,9 @@ namespace DataTables.NetStandard
         /// </summary>
         /// <param name="configuration"></param>
         /// <param name="columns"></param>
-        protected virtual void ConfigureColumns(DataTablesConfiguration configuration, IList<DataTablesColumn<TEntity, TEntityViewModel>> columns)
+        protected virtual void ConfigureColumns(
+            DataTablesConfiguration configuration,
+            IList<DataTablesColumn<TEntity, TEntityViewModel>> columns)
         {
             foreach (var column in columns)
             {
@@ -241,7 +241,9 @@ namespace DataTables.NetStandard
         /// </summary>
         /// <param name="configuration"></param>
         /// <param name="columns"></param>
-        protected virtual void ConfigureColumnOrdering(DataTablesConfiguration configuration, IList<DataTablesColumn<TEntity, TEntityViewModel>> columns)
+        protected virtual void ConfigureColumnOrdering(
+            DataTablesConfiguration configuration,
+            IList<DataTablesColumn<TEntity, TEntityViewModel>> columns)
         {
             var orderedColumns = columns.Where(c => c.OrderingIndex > -1).OrderBy(c => c.OrderingIndex);
             foreach (var column in orderedColumns)
@@ -259,7 +261,9 @@ namespace DataTables.NetStandard
         /// </summary>
         /// <param name="configuration"></param>
         /// <param name="columns"></param>
-        protected virtual void ConfigureAdditionalOptions(DataTablesConfiguration configuration, IList<DataTablesColumn<TEntity, TEntityViewModel>> columns)
+        protected virtual void ConfigureAdditionalOptions(
+            DataTablesConfiguration configuration,
+            IList<DataTablesColumn<TEntity, TEntityViewModel>> columns)
         {
             // We don't configure anything here, but we provide a default implementation.
         }
@@ -361,7 +365,6 @@ namespace DataTables.NetStandard
         /// <paramref name="query"/>, <see cref="Columns"/> and <see cref="MappingFunction"/>.
         /// </summary>
         /// <param name="query">The query.</param>
-        /// <returns></returns>
         protected virtual DataTablesRequest<TEntity, TEntityViewModel> BuildRequest(string query)
         {
             return new DataTablesRequest<TEntity, TEntityViewModel>(query, Columns(), MappingFunction());

--- a/DataTables.NetStandard/DataTables.NetStandard.csproj
+++ b/DataTables.NetStandard/DataTables.NetStandard.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.1.0</Version>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
-    <Authors>Namoshek</Authors>
-    <Company>Namoshek</Company>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+    <Authors>Namoshek (Marvin Mall)</Authors>
+    <Company>Namoshek (Marvin Mall)</Company>
     <PackageId>DataTables.NetStandard</PackageId>
     <Product>DataTables.NetStandard</Product>
     <Description>Self-containing DataTable classes for the datatables.net jQuery plugin that manage rendering, querying, filtering, sorting and other desireable tasks for the user.</Description>
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/DataTables.NetStandard/DataTablesAjaxPostModel.cs
+++ b/DataTables.NetStandard/DataTablesAjaxPostModel.cs
@@ -117,13 +117,14 @@ namespace DataTables.NetStandard
         /// </returns>
         internal NameValueCollection ToNameValueCollection()
         {
-            var model = new NameValueCollection();
-
-            model["draw"] = Draw.ToString();
-            model["start"] = Start.ToString();
-            model["length"] = Length.ToString();
-            model[$"search[value]"] = Search.Value;
-            model[$"search[regex]"] = Search.Regex.ToString();
+            var model = new NameValueCollection
+            {
+                ["draw"] = Draw.ToString(),
+                ["start"] = Start.ToString(),
+                ["length"] = Length.ToString(),
+                [$"search[value]"] = Search.Value,
+                [$"search[regex]"] = Search.Regex.ToString()
+            };
 
             for (int i = 0; i < Columns.Count; i++)
             {

--- a/DataTables.NetStandard/DataTablesColumn.cs
+++ b/DataTables.NetStandard/DataTablesColumn.cs
@@ -7,13 +7,13 @@ using DataTables.NetStandard.Extensions;
 namespace DataTables.NetStandard
 {
     /// <summary>
-    /// Represents DataTables column filtering/sorting info
+    /// Represents the server-side column filtering/sorting configuration for a DataTable.
     /// </summary>
     /// <typeparam name="TEntity">Model type</typeparam>
     public class DataTablesColumn<TEntity, TEntityViewModel> : ICloneable
     {
         /// <summary>
-        /// Column's index
+        /// The index of the column.
         /// </summary>
         public int Index { get; set; }
 

--- a/DataTables.NetStandard/DataTablesQueryProvider.cs
+++ b/DataTables.NetStandard/DataTablesQueryProvider.cs
@@ -5,18 +5,18 @@ namespace DataTables.NetStandard
 {
     internal class DataTablesQueryProvider<TEntity, TEntityViewModel> : IQueryProvider
     {
-        private IQueryProvider sourceProvider;
-        private DataTablesRequest<TEntity, TEntityViewModel> request;
+        private readonly IQueryProvider _sourceProvider;
+        private readonly DataTablesRequest<TEntity, TEntityViewModel> _request;
 
         internal DataTablesQueryProvider(IQueryProvider sourceProvider, DataTablesRequest<TEntity, TEntityViewModel> request)
         {
-            this.sourceProvider = sourceProvider;
-            this.request = request;
+            _sourceProvider = sourceProvider;
+            _request = request;
         }
 
         public IQueryable CreateQuery(Expression expression)
         {
-            return new DataTablesQueryable<TEntity, TEntityViewModel>((IQueryable<TEntity>)sourceProvider.CreateQuery(expression), request);
+            return new DataTablesQueryable<TEntity, TEntityViewModel>((IQueryable<TEntity>)_sourceProvider.CreateQuery(expression), _request);
         }
 
         public IQueryable<TResult> CreateQuery<TResult>(Expression expression)
@@ -26,12 +26,12 @@ namespace DataTables.NetStandard
 
         public object Execute(Expression expression)
         {
-            return sourceProvider.Execute(expression);
+            return _sourceProvider.Execute(expression);
         }
 
         public TResult Execute<TResult>(Expression expression)
         {
-            return (TResult)sourceProvider.Execute(expression);
+            return (TResult)_sourceProvider.Execute(expression);
         }
     }
 }

--- a/DataTables.NetStandard/DataTablesQueryable.cs
+++ b/DataTables.NetStandard/DataTablesQueryable.cs
@@ -26,8 +26,8 @@ namespace DataTables.NetStandard
     /// <typeparam name="TEntity">Model type</typeparam>
     internal class DataTablesQueryable<TEntity, TEntityViewModel> : IDataTablesQueryable<TEntity, TEntityViewModel>
     {
-        private IQueryable<TEntity> _sourceQueryable;
-        private DataTablesQueryProvider<TEntity, TEntityViewModel> _sourceProvider;
+        private readonly IQueryable<TEntity> _sourceQueryable;
+        private readonly DataTablesQueryProvider<TEntity, TEntityViewModel> _sourceProvider;
 
         public DataTablesRequest<TEntity, TEntityViewModel> Request { get; }
 

--- a/DataTables.NetStandard/DataTablesRequest.cs
+++ b/DataTables.NetStandard/DataTablesRequest.cs
@@ -25,7 +25,8 @@ namespace DataTables.NetStandard
         public int PageSize { get; set; }
 
         /// <summary>
-        /// Draw counter. This is used by DataTables to ensure that the Ajax returns from server-side processing requests are drawn in sequence by DataTables.
+        /// Draw counter. This is used by DataTables to ensure that the Ajax returns from server-side processing requests
+        /// are drawn in sequence by DataTables.
         /// </summary>
         public int Draw { get; set; }
 
@@ -65,7 +66,8 @@ namespace DataTables.NetStandard
         /// var column = request.Columns[s => s.FirstName];
         /// </code>
         /// </example>
-        public IList<DataTablesColumn<TEntity, TEntityViewModel>> Columns { get; private set; } = new List<DataTablesColumn<TEntity, TEntityViewModel>>();
+        public IList<DataTablesColumn<TEntity, TEntityViewModel>> Columns { get; private set; } =
+            new List<DataTablesColumn<TEntity, TEntityViewModel>>();
 
         /// <summary>
         /// Set this property to log incoming request parameters and resulting queries to the given delegate. 
@@ -99,51 +101,69 @@ namespace DataTables.NetStandard
         }
 
         /// <summary>
-        /// Creates new <see cref="DataTablesRequest{T}"/> from <see cref="IDictionary{String, Object}"/>.
-        /// This constructor is useful with it's needed to create <see cref="DataTablesRequest{T}"/> from the Nancy's <a href="https://github.com/NancyFx/Nancy/blob/master/src/Nancy/Request.cs">Request.Form</a> data.
+        /// Creates new <see cref="DataTablesRequest{TEntity, TEntityViewModel}"/> from <see cref="IDictionary{String, Object}"/>.
+        /// This constructor is useful to create <see cref="DataTablesRequest{TEntity, TEntityViewModel}"/> from
+        /// Nancy's <a href="https://github.com/NancyFx/Nancy/blob/master/src/Nancy/Request.cs">Request.Form</a> data.
         /// </summary>
         /// <param name="form">Request form data</param>
         /// <param name="columns">DataTable columns</param>
         /// <param name="mappingFunction">View model mapping function</param>
         public DataTablesRequest(IDictionary<string, object> form, IList<DataTablesColumn<TEntity, TEntityViewModel>> columns, 
             Expression<Func<TEntity, TEntityViewModel>> mappingFunction)
-            : this(form.Aggregate(new NameValueCollection(), (k, v) => { k.Add(v.Key, v.Value.ToString()); return k; }), columns, mappingFunction) { }
+            : this(form.Aggregate(new NameValueCollection(), (k, v) => { k.Add(v.Key, v.Value.ToString()); return k; }), columns, mappingFunction)
+        {
+        }
 
         /// <summary>
-        /// Creates new <see cref="DataTablesRequest{T}"/> from <see cref="DataTablesAjaxPostModel"/>.
+        /// Creates new <see cref="DataTablesRequest{TEntity, TEntityViewModel}"/> from <see cref="DataTablesAjaxPostModel"/>.
         /// </summary>
         /// <param name="ajaxPostModel">Contains datatables parameters sent from client side when POST method is used.</param>
         /// <param name="columns">DataTable columns</param>
         /// <param name="mappingFunction">View model mapping function</param>
         public DataTablesRequest(DataTablesAjaxPostModel ajaxPostModel, IList<DataTablesColumn<TEntity, TEntityViewModel>> columns,
             Expression<Func<TEntity, TEntityViewModel>> mappingFunction)
-            : this(ajaxPostModel.ToNameValueCollection(), columns, mappingFunction) { }
+            : this(ajaxPostModel.ToNameValueCollection(), columns, mappingFunction)
+        {
+        }
 
         /// <summary>
-        /// Creates new <see cref="DataTablesRequest{T}"/> from <see cref="Uri"/> instance.
+        /// Creates new <see cref="DataTablesRequest{TEntity, TEntityViewModel}"/> from <see cref="Uri"/> instance.
         /// </summary>
         /// <param name="uri"><see cref="Uri"/> instance</param>
         /// <param name="columns">DataTable columns</param>
         /// <param name="mappingFunction">View model mapping function</param>
-        public DataTablesRequest(Uri uri, IList<DataTablesColumn<TEntity, TEntityViewModel>> columns, Expression<Func<TEntity, TEntityViewModel>> mappingFunction)
-            : this(uri.Query, columns, mappingFunction) { }
+        public DataTablesRequest(
+            Uri uri,
+            IList<DataTablesColumn<TEntity, TEntityViewModel>> columns,
+            Expression<Func<TEntity, TEntityViewModel>> mappingFunction)
+            : this(uri.Query, columns, mappingFunction)
+        {
+        }
 
         /// <summary>
-        /// Creates new <see cref="DataTablesRequest{T}"/> from http query string.
+        /// Creates new <see cref="DataTablesRequest{TEntity, TEntityViewModel}"/> from http query string.
         /// </summary>
         /// <param name="queryString"></param>
         /// <param name="columns">DataTable columns</param>
         /// <param name="mappingFunction">View model mapping function</param>
-        public DataTablesRequest(string queryString, IList<DataTablesColumn<TEntity, TEntityViewModel>> columns, Expression<Func<TEntity, TEntityViewModel>> mappingFunction)
-            : this(HttpUtility.ParseQueryString(queryString), columns, mappingFunction) { }
+        public DataTablesRequest(
+            string queryString,
+            IList<DataTablesColumn<TEntity, TEntityViewModel>> columns,
+            Expression<Func<TEntity, TEntityViewModel>> mappingFunction)
+            : this(HttpUtility.ParseQueryString(queryString), columns, mappingFunction)
+        {
+        }
 
         /// <summary>
-        /// Creates new <see cref="DataTablesRequest{T}"/> from <see cref="NameValueCollection"/> instance.
+        /// Creates new <see cref="DataTablesRequest{TEntity, TEntityViewModel}"/> from <see cref="NameValueCollection"/> instance.
         /// </summary>
         /// <param name="query"></param>
         /// <param name="columns">DataTable columns</param>
         /// <param name="mappingFunction">View model mapping function</param>
-        public DataTablesRequest(NameValueCollection query, IList<DataTablesColumn<TEntity, TEntityViewModel>> columns, Expression<Func<TEntity, TEntityViewModel>> mappingFunction)
+        public DataTablesRequest(
+            NameValueCollection query,
+            IList<DataTablesColumn<TEntity, TEntityViewModel>> columns,
+            Expression<Func<TEntity, TEntityViewModel>> mappingFunction)
         {
             if (query == null)
             {
@@ -179,7 +199,7 @@ namespace DataTables.NetStandard
             Draw = int.TryParse(query["draw"], out int draw) ? draw : 0;
 
             GlobalSearchValue = query["search[value]"];
-            GlobalSearchRegex = bool.TryParse(query["search[regex]"], out bool searchRegex) ? searchRegex : false;
+            GlobalSearchRegex = bool.TryParse(query["search[regex]"], out bool searchRegex) && searchRegex;
         }
 
         /// <summary>

--- a/DataTables.NetStandard/DataTablesRequest.cs
+++ b/DataTables.NetStandard/DataTablesRequest.cs
@@ -108,7 +108,7 @@ namespace DataTables.NetStandard
         /// <param name="form">Request form data</param>
         /// <param name="columns">DataTable columns</param>
         /// <param name="mappingFunction">View model mapping function</param>
-        public DataTablesRequest(IDictionary<string, object> form, IList<DataTablesColumn<TEntity, TEntityViewModel>> columns, 
+        public DataTablesRequest(IDictionary<string, object> form, IList<DataTablesColumn<TEntity, TEntityViewModel>> columns,
             Expression<Func<TEntity, TEntityViewModel>> mappingFunction)
             : this(form.Aggregate(new NameValueCollection(), (k, v) => { k.Add(v.Key, v.Value.ToString()); return k; }), columns, mappingFunction)
         {
@@ -262,7 +262,7 @@ namespace DataTables.NetStandard
                     {
                         column.OrderingIndex = sortingIndex;
                         column.OrderingDirection = query[$"order[{index}][dir]"] == "desc"
-                            ? ListSortDirection.Descending 
+                            ? ListSortDirection.Descending
                             : ListSortDirection.Ascending;
                     }
                 }

--- a/DataTables.NetStandard/DataTablesResponse.cs
+++ b/DataTables.NetStandard/DataTablesResponse.cs
@@ -38,10 +38,8 @@ namespace DataTables.NetStandard
         }
 
         /// <summary>
-        /// Serializes the whole entity as JSON string. Uses the column configurations to properly
-        /// format the result and its keys.
+        /// Serializes the whole entity as JSON string. Uses the column configurations to properly format the result and its keys.
         /// </summary>
-        /// <returns></returns>
         public string AsJsonString()
         {
             return JsonConvert.SerializeObject(this, new JsonSerializerSettings

--- a/DataTables.NetStandard/DataTablesSerializationContractResolver.cs
+++ b/DataTables.NetStandard/DataTablesSerializationContractResolver.cs
@@ -16,7 +16,7 @@ namespace DataTables.NetStandard
     /// <seealso cref="DefaultContractResolver" />
     internal class DataTablesSerializationContractResolver<TEntity, TEntityViewModel> : DefaultContractResolver
     {
-        protected readonly IList<DataTablesColumn<TEntity, TEntityViewModel>> _columns;
+        private readonly IList<DataTablesColumn<TEntity, TEntityViewModel>> _columns;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DataTablesSerializationContractResolver{TEntity, TEntityViewModel}"/> class.
@@ -59,15 +59,13 @@ namespace DataTables.NetStandard
         {
             var members = base.GetSerializableMembers(objectType);
 
-            // If the current type is not the view model type of our DataTables columns,
-            // we don't have to change anything.
+            // If the current type is not the view model type of our DataTables columns, we don't have to change anything.
             if (!_columns.GetType().GenericTypeArguments.First().GenericTypeArguments.Last().Equals(objectType))
             {
                 return members;
             }
 
-            // We only want to serialize members which are referenced by any table column within the
-            // `PublicPropertyName` property.
+            // We only want to serialize members which are referenced by any table column within the `PublicPropertyName` property.
             var result = new List<MemberInfo>();
             foreach (var member in members)
             {

--- a/DataTables.NetStandard/Extensions/EnumerableExtensions.cs
+++ b/DataTables.NetStandard/Extensions/EnumerableExtensions.cs
@@ -14,7 +14,8 @@ namespace DataTables.NetStandard.Extensions
         /// <param name="source">The source.</param>
         /// <param name="request">The request.</param>
         public static IPagedList<TEntityViewModel> ToPagedList<TEntity, TEntityViewModel>(
-            this IEnumerable<TEntity> source, DataTablesRequest<TEntity, TEntityViewModel> request)
+            this IEnumerable<TEntity> source,
+            DataTablesRequest<TEntity, TEntityViewModel> request)
         {
             return source.AsQueryable().ToPagedList(request);
         }
@@ -27,7 +28,8 @@ namespace DataTables.NetStandard.Extensions
         /// <param name="source">The source.</param>
         /// <param name="request">The request.</param>
         public static Task<IPagedList<TEntityViewModel>> ToPagedListAsync<TEntity, TEntityViewModel>(
-            this IEnumerable<TEntity> source, DataTablesRequest<TEntity, TEntityViewModel> request)
+            this IEnumerable<TEntity> source,
+            DataTablesRequest<TEntity, TEntityViewModel> request)
         {
             return Task.Factory.StartNew(() => source.AsQueryable().ToPagedList(request));
         }

--- a/DataTables.NetStandard/Extensions/ExpressionExtensions.cs
+++ b/DataTables.NetStandard/Extensions/ExpressionExtensions.cs
@@ -4,12 +4,12 @@ using System.Text;
 namespace DataTables.NetStandard.Extensions
 {
     /// <summary>
-    /// Utility extension methods for <see cref="Expression" />
+    /// Utility extension methods for <see cref="Expression" />.
     /// </summary>
     internal static class ExpressionExtensions
     {
         /// <summary>
-        /// Gets property path from an expression
+        /// Gets the property path from an expression.
         /// </summary>
         /// <param name="expr">Expression instance, for example 'p => p.Office.Street.Address'.</param>
         /// <returns>Full property path like "Office.Street.Address"</returns>
@@ -24,7 +24,9 @@ namespace DataTables.NetStandard.Extensions
                 {
                     path.Insert(0, ".");
                 }
+                
                 path.Insert(0, memberExpression.Member.Name);
+
                 memberExpression = GetMemberExpression(memberExpression.Expression);
             }
             while (memberExpression != null);
@@ -32,22 +34,29 @@ namespace DataTables.NetStandard.Extensions
             return path.ToString();
         }
 
+        /// <summary>
+        /// Retrieve the nearest <see cref="MemberExpression"/> from the given <paramref name="expression"/>.
+        /// </summary>
+        /// <param name="expression"></param>
         private static MemberExpression GetMemberExpression(Expression expression)
         {
-            if (expression is MemberExpression)
+            if (expression is MemberExpression memberExpression)
             {
-                return (MemberExpression)expression;
+                return memberExpression;
             }
-            else if (expression is LambdaExpression)
+
+            if (expression is LambdaExpression)
             {
                 var lambdaExpression = expression as LambdaExpression;
-                if (lambdaExpression.Body is MemberExpression)
+                
+                if (lambdaExpression.Body is MemberExpression memberExpression2)
                 {
-                    return (MemberExpression)lambdaExpression.Body;
+                    return memberExpression2;
                 }
-                else if (lambdaExpression.Body is UnaryExpression)
+
+                if (lambdaExpression.Body is UnaryExpression unaryExpression)
                 {
-                    return ((MemberExpression)((UnaryExpression)lambdaExpression.Body).Operand);
+                    return (MemberExpression)unaryExpression.Operand;
                 }
             }
 

--- a/DataTables.NetStandard/Extensions/ExpressionExtensions.cs
+++ b/DataTables.NetStandard/Extensions/ExpressionExtensions.cs
@@ -24,7 +24,7 @@ namespace DataTables.NetStandard.Extensions
                 {
                     path.Insert(0, ".");
                 }
-                
+
                 path.Insert(0, memberExpression.Member.Name);
 
                 memberExpression = GetMemberExpression(memberExpression.Expression);
@@ -48,7 +48,7 @@ namespace DataTables.NetStandard.Extensions
             if (expression is LambdaExpression)
             {
                 var lambdaExpression = expression as LambdaExpression;
-                
+
                 if (lambdaExpression.Body is MemberExpression memberExpression2)
                 {
                     return memberExpression2;

--- a/DataTables.NetStandard/Extensions/QueryableExtensions.cs
+++ b/DataTables.NetStandard/Extensions/QueryableExtensions.cs
@@ -20,7 +20,8 @@ namespace DataTables.NetStandard.Extensions
         /// <typeparam name="TEntityViewModel">The type of the entity view model.</typeparam>
         /// <param name="queryable">The queryable.</param>
         /// <param name="request">The request.</param>
-        public static IPagedList<TEntityViewModel> ToPagedList<TEntity, TEntityViewModel>(this IQueryable<TEntity> queryable, 
+        public static IPagedList<TEntityViewModel> ToPagedList<TEntity, TEntityViewModel>(
+            this IQueryable<TEntity> queryable, 
             DataTablesRequest<TEntity, TEntityViewModel> request)
         {
             return queryable.Apply(request).ToPagedList();
@@ -35,7 +36,8 @@ namespace DataTables.NetStandard.Extensions
         /// <typeparam name="TEntityViewModel">The type of the entity view model.</typeparam>
         /// <param name="queryable">The queryable.</param>
         /// <param name="request">The request.</param>
-        public static Task<IPagedList<TEntityViewModel>> ToPagedListAsync<TEntity, TEntityViewModel>(this IQueryable<TEntity> queryable, 
+        public static Task<IPagedList<TEntityViewModel>> ToPagedListAsync<TEntity, TEntityViewModel>(
+            this IQueryable<TEntity> queryable, 
             DataTablesRequest<TEntity, TEntityViewModel> request)
         {
             return queryable.Apply(request).ToPagedListAsync();
@@ -51,7 +53,8 @@ namespace DataTables.NetStandard.Extensions
         /// <param name="queryable">The queryable.</param>
         /// <param name="request">The request.</param>
         public static IDataTablesQueryable<TEntity, TEntityViewModel> Apply<TEntity, TEntityViewModel>(
-            this IQueryable<TEntity> queryable, DataTablesRequest<TEntity, TEntityViewModel> request)
+            this IQueryable<TEntity> queryable,
+            DataTablesRequest<TEntity, TEntityViewModel> request)
         {
             queryable = queryable.AsDataTablesQueryable(request)
                 .ApplyGlobalSearchFilter()
@@ -86,7 +89,8 @@ namespace DataTables.NetStandard.Extensions
         /// <param name="queryable">The queryable.</param>
         /// <param name="request">The request.</param>
         public static IDataTablesQueryable<TEntity, TEntityViewModel> AsDataTablesQueryable<TEntity, TEntityViewModel>(
-            this IQueryable<TEntity> queryable, DataTablesRequest<TEntity, TEntityViewModel> request)
+            this IQueryable<TEntity> queryable,
+            DataTablesRequest<TEntity, TEntityViewModel> request)
         {
             return new DataTablesQueryable<TEntity, TEntityViewModel>(queryable, request);
         }
@@ -102,8 +106,12 @@ namespace DataTables.NetStandard.Extensions
         /// <param name="direction">The direction.</param>
         /// <param name="caseInsensitive">if set to <c>true</c>, the order logic is case insensitive.</param>
         /// <param name="alreadyOrdered">if set to <c>true</c>, follow-up order logic will be used.</param>
-        internal static IQueryable<TEntity> OrderBy<TEntity>(this IQueryable<TEntity> query, 
-            string propertyName, ListSortDirection direction, bool caseInsensitive, bool alreadyOrdered)
+        internal static IQueryable<TEntity> OrderBy<TEntity>(
+            this IQueryable<TEntity> query, 
+            string propertyName,
+            ListSortDirection direction,
+            bool caseInsensitive,
+            bool alreadyOrdered)
         {
             var type = typeof(TEntity);
             var parameterExp = Expression.Parameter(type, $"e{RandomNumberGenerator.GetInt32(int.MaxValue)}");
@@ -135,8 +143,11 @@ namespace DataTables.NetStandard.Extensions
         /// <param name="orderExpression">Name of the property.</param>
         /// <param name="direction">The direction.</param>
         /// <param name="alreadyOrdered">if set to <c>true</c>, follow-up order logic will be used.</param>
-        internal static IQueryable<TEntity> OrderBy<TEntity>(this IQueryable<TEntity> query, 
-            Expression<Func<TEntity, object>> orderExpression, ListSortDirection direction, bool alreadyOrdered)
+        internal static IQueryable<TEntity> OrderBy<TEntity>(
+            this IQueryable<TEntity> query, 
+            Expression<Func<TEntity, object>> orderExpression,
+            ListSortDirection direction,
+            bool alreadyOrdered)
         {
             var methodName = GetOrderMethodName(direction, alreadyOrdered);
             var typeArguments = new Type[] { typeof(TEntity), typeof(object) };
@@ -151,20 +162,16 @@ namespace DataTables.NetStandard.Extensions
         /// </summary>
         /// <param name="direction">The order direction.</param>
         /// <param name="alreadyOrdered">if set to <c>true</c>, an order method for already ordered queryables will be returned.</param>
-        /// <returns></returns>
         internal static string GetOrderMethodName(ListSortDirection direction, bool alreadyOrdered)
         {
-            if (direction == ListSortDirection.Descending && !alreadyOrdered)
-                return nameof(Queryable.OrderByDescending);
+            return (direction, alreadyOrdered) switch
+            {
+                (ListSortDirection.Descending, false) => nameof(Queryable.OrderByDescending),
+                (ListSortDirection.Ascending, true) => nameof(Queryable.ThenBy),
+                (ListSortDirection.Descending, true) => nameof(Queryable.ThenByDescending),
 
-            if (direction == ListSortDirection.Ascending && alreadyOrdered)
-                return nameof(Queryable.ThenBy);
-
-            if (direction == ListSortDirection.Descending && alreadyOrdered)
-                return nameof(Queryable.ThenByDescending);
-
-            // direction == ListSortDirection.Ascending && alreadyOrdered == false
-            return nameof(Queryable.OrderBy);
+                _ => nameof(Queryable.OrderBy),
+            };
         }
     }
 }

--- a/DataTables.NetStandard/Extensions/QueryableExtensions.cs
+++ b/DataTables.NetStandard/Extensions/QueryableExtensions.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using DataTables.NetStandard.Util;
@@ -105,7 +106,7 @@ namespace DataTables.NetStandard.Extensions
             string propertyName, ListSortDirection direction, bool caseInsensitive, bool alreadyOrdered)
         {
             var type = typeof(TEntity);
-            var parameterExp = Expression.Parameter(type, "e");
+            var parameterExp = Expression.Parameter(type, $"e{RandomNumberGenerator.GetInt32(int.MaxValue)}");
             var propertyExp = ExpressionHelper.BuildPropertyExpression(parameterExp, propertyName);
 
             Expression exp = propertyExp;

--- a/DataTables.NetStandard/Extensions/QueryableExtensions.cs
+++ b/DataTables.NetStandard/Extensions/QueryableExtensions.cs
@@ -21,7 +21,7 @@ namespace DataTables.NetStandard.Extensions
         /// <param name="queryable">The queryable.</param>
         /// <param name="request">The request.</param>
         public static IPagedList<TEntityViewModel> ToPagedList<TEntity, TEntityViewModel>(
-            this IQueryable<TEntity> queryable, 
+            this IQueryable<TEntity> queryable,
             DataTablesRequest<TEntity, TEntityViewModel> request)
         {
             return queryable.Apply(request).ToPagedList();
@@ -37,7 +37,7 @@ namespace DataTables.NetStandard.Extensions
         /// <param name="queryable">The queryable.</param>
         /// <param name="request">The request.</param>
         public static Task<IPagedList<TEntityViewModel>> ToPagedListAsync<TEntity, TEntityViewModel>(
-            this IQueryable<TEntity> queryable, 
+            this IQueryable<TEntity> queryable,
             DataTablesRequest<TEntity, TEntityViewModel> request)
         {
             return queryable.Apply(request).ToPagedListAsync();
@@ -107,7 +107,7 @@ namespace DataTables.NetStandard.Extensions
         /// <param name="caseInsensitive">if set to <c>true</c>, the order logic is case insensitive.</param>
         /// <param name="alreadyOrdered">if set to <c>true</c>, follow-up order logic will be used.</param>
         internal static IQueryable<TEntity> OrderBy<TEntity>(
-            this IQueryable<TEntity> query, 
+            this IQueryable<TEntity> query,
             string propertyName,
             ListSortDirection direction,
             bool caseInsensitive,
@@ -144,7 +144,7 @@ namespace DataTables.NetStandard.Extensions
         /// <param name="direction">The direction.</param>
         /// <param name="alreadyOrdered">if set to <c>true</c>, follow-up order logic will be used.</param>
         internal static IQueryable<TEntity> OrderBy<TEntity>(
-            this IQueryable<TEntity> query, 
+            this IQueryable<TEntity> query,
             Expression<Func<TEntity, object>> orderExpression,
             ListSortDirection direction,
             bool alreadyOrdered)

--- a/DataTables.NetStandard/Extensions/StringExtensions.cs
+++ b/DataTables.NetStandard/Extensions/StringExtensions.cs
@@ -18,7 +18,7 @@ namespace DataTables.NetStandard.Extensions
             {
                 null => throw new ArgumentNullException(nameof(input)),
                 "" => throw new ArgumentException($"{nameof(input)} cannot be empty", nameof(input)),
-                
+
                 _ => input.First().ToString().ToUpper() + input[1..],
             };
         }

--- a/DataTables.NetStandard/Extensions/StringExtensions.cs
+++ b/DataTables.NetStandard/Extensions/StringExtensions.cs
@@ -5,24 +5,22 @@ namespace DataTables.NetStandard.Extensions
 {
     internal static class StringExtensions
     {
+        /// <summary>
+        /// If the given <paramref name="input"/> is not <c>null</c> and not empty, returns a string with the first character in upper case.
+        /// For <c>null</c> and empty strings, an exception is thrown.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <exception cref="ArgumentNullException">If <paramref name="input"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="input"/> is empty.</exception>
         public static string FirstCharToUpper(this string input)
         {
-            switch (input)
+            return input switch
             {
-                case null: throw new ArgumentNullException(nameof(input));
-                case "": throw new ArgumentException($"{nameof(input)} cannot be empty", nameof(input));
-                default: return input.First().ToString().ToUpper() + input.Substring(1);
-            }
-        }
-
-        public static string FirstCharToLower(this string input)
-        {
-            switch (input)
-            {
-                case null: throw new ArgumentNullException(nameof(input));
-                case "": throw new ArgumentException($"{nameof(input)} cannot be empty", nameof(input));
-                default: return input.First().ToString().ToLower() + input.Substring(1);
-            }
+                null => throw new ArgumentNullException(nameof(input)),
+                "" => throw new ArgumentException($"{nameof(input)} cannot be empty", nameof(input)),
+                
+                _ => input.First().ToString().ToUpper() + input[1..],
+            };
         }
     }
 }

--- a/DataTables.NetStandard/Extensions/TypeExtensions.cs
+++ b/DataTables.NetStandard/Extensions/TypeExtensions.cs
@@ -10,24 +10,24 @@ namespace DataTables.NetStandard.Extensions
         /// Gets <see cref="PropertyInfo"/> from full property name.
         /// </summary>
         /// <param name="type">Type to get the property from</param>
-        /// <param name="propertyName">Full property name. Can contain dots, like "SomeProperty.NestedProperty" to access to nested comlplex types.</param>
-        /// <returns><see cref="PropertyInfo"/> instance.</returns>
+        /// <param name="propertyName">Full property name. Can contain dots, like "SomeProperty.NestedProperty" to access nested properties.</param>
         internal static PropertyInfo GetPropertyByName(this Type type, string propertyName)
         {
             string[] parts = propertyName.Split('.');
+            
             if (parts.Length > 1)
             {
                 var propertyInfo = type.GetProperty(parts[0]);
+                
                 if (propertyInfo == null)
                 {
                     return null;
                 }
+
                 return GetPropertyByName(propertyInfo.PropertyType, parts.Skip(1).Aggregate((a, i) => $"{a}.{i}"));
             }
-            else
-            {
-                return type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
-            }
+
+            return type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
         }
     }
 }

--- a/DataTables.NetStandard/Extensions/TypeExtensions.cs
+++ b/DataTables.NetStandard/Extensions/TypeExtensions.cs
@@ -14,11 +14,11 @@ namespace DataTables.NetStandard.Extensions
         internal static PropertyInfo GetPropertyByName(this Type type, string propertyName)
         {
             string[] parts = propertyName.Split('.');
-            
+
             if (parts.Length > 1)
             {
                 var propertyInfo = type.GetProperty(parts[0]);
-                
+
                 if (propertyInfo == null)
                 {
                     return null;

--- a/DataTables.NetStandard/PagedList.cs
+++ b/DataTables.NetStandard/PagedList.cs
@@ -1,7 +1,7 @@
-﻿using DataTables.NetStandard.Abstract;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using DataTables.NetStandard.Abstract;
 
 namespace DataTables.NetStandard
 {

--- a/DataTables.NetStandard/PagedList.cs
+++ b/DataTables.NetStandard/PagedList.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using DataTables.NetStandard.Abstract;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using DataTables.NetStandard.Abstract;
 
 namespace DataTables.NetStandard
 {
@@ -18,10 +18,10 @@ namespace DataTables.NetStandard
     /// <typeparam name="TEntity">Data type</typeparam>
     internal class PagedList<TEntity, TEntityViewModel> : List<TEntityViewModel>, IPagedList<TEntityViewModel>
     {
-        public int TotalCount { get; protected set; }
-        public int PageNumber { get; protected set; }
-        public int PageSize { get; protected set; }
-        public int PagesCount { get; protected set; }
+        public int TotalCount { get; }
+        public int PageNumber { get; }
+        public int PageSize { get; }
+        public int PagesCount { get; }
 
         internal PagedList(IPagedList other) : base()
         {

--- a/DataTables.NetStandard/Util/ExpressionHelper.cs
+++ b/DataTables.NetStandard/Util/ExpressionHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 
 namespace DataTables.NetStandard.Util
@@ -35,7 +36,7 @@ namespace DataTables.NetStandard.Util
         {
             var type = typeof(TEntity);
 
-            return Expression.Parameter(type, "e");
+            return Expression.Parameter(type, $"e{RandomNumberGenerator.GetInt32(int.MaxValue)}");
         }
 
         /// <summary>

--- a/DataTables.NetStandard/Util/ExpressionHelper.cs
+++ b/DataTables.NetStandard/Util/ExpressionHelper.cs
@@ -29,7 +29,7 @@ namespace DataTables.NetStandard.Util
         internal static readonly MethodInfo Regex_IsMatch = typeof(Regex).GetMethod(nameof(Regex.IsMatch), new[] { typeof(string), typeof(string) });
 
         /// <summary>
-        /// Builds a parameter expression for the given type
+        /// Builds a parameter expression for the given type.
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         internal static ParameterExpression BuildParameterExpression<TEntity>()
@@ -67,7 +67,10 @@ namespace DataTables.NetStandard.Util
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="stringConstant">The string constant.</param>
         /// <param name="caseInsensitive">if set to <c>true</c> [case insensitive].</param>
-        internal static Expression<Func<TEntity, bool>> BuildStringContainsPredicate<TEntity>(string propertyName, string stringConstant, bool caseInsensitive)
+        internal static Expression<Func<TEntity, bool>> BuildStringContainsPredicate<TEntity>(
+            string propertyName,
+            string stringConstant,
+            bool caseInsensitive)
         {
             var parameterExp = BuildParameterExpression<TEntity>();
             var propertyExp = BuildPropertyExpression(parameterExp, propertyName);

--- a/DataTables.NetStandard/Util/ExpressionHelper.cs
+++ b/DataTables.NetStandard/Util/ExpressionHelper.cs
@@ -81,7 +81,7 @@ namespace DataTables.NetStandard.Util
             {
                 exp = Expression.Call(propertyExp, Object_ToString);
             }
-            
+
             if (caseInsensitive)
             {
                 exp = Expression.Call(exp, String_ToLower);


### PR DESCRIPTION
This PR updates the library to use `netstandard2.1`. The sample project is updated to use EFCore 6, including a fix for expression caching (was changed in EFCore 5).

Besides these major changes, the code got a bit of a cleanup and refactoring.