### PR TITLE
Fix created lambda expressions by creating a fresh parameter

### DIFF
--- a/DataTables.NetStandard/DataTables.NetStandard.csproj
+++ b/DataTables.NetStandard/DataTables.NetStandard.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.0</Version>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
+    <Version>3.0.1</Version>
+    <AssemblyVersion>3.0.1.0</AssemblyVersion>
+    <FileVersion>3.0.1.0</FileVersion>
     <Authors>Namoshek (Marvin Mall)</Authors>
     <Company>Namoshek (Marvin Mall)</Company>
     <PackageId>DataTables.NetStandard</PackageId>

--- a/DataTables.NetStandard/Extensions/QueryableExtensions.cs
+++ b/DataTables.NetStandard/Extensions/QueryableExtensions.cs
@@ -97,8 +97,7 @@ namespace DataTables.NetStandard.Extensions
             bool caseInsensitive,
             bool alreadyOrdered)
         {
-            var type = typeof(TEntity);
-            var parameterExp = Expression.Parameter(type);
+            var parameterExp = ExpressionHelper.BuildParameterExpression<TEntity>();
             var propertyExp = ExpressionHelper.BuildPropertyExpression(parameterExp, propertyName);
 
             Expression exp = propertyExp;
@@ -110,7 +109,7 @@ namespace DataTables.NetStandard.Extensions
 
             var methodName = GetOrderMethodName(direction, alreadyOrdered);
             var orderByExp = Expression.Lambda(exp, parameterExp);
-            var typeArguments = new Type[] { type, propertyExp.Type };
+            var typeArguments = new Type[] { typeof(TEntity), propertyExp.Type };
 
             var resultExpr = Expression.Call(typeof(Queryable), methodName, typeArguments, query.Expression, Expression.Quote(orderByExp));
 
@@ -200,7 +199,7 @@ namespace DataTables.NetStandard.Extensions
                         if (searchPredicate != null)
                         {
                             var expr = searchPredicate;
-                            var entityParam = expr.Parameters.Single(p => p.Type == typeof(TEntity));
+                            var entityParam = ExpressionHelper.BuildParameterExpression<TEntity>();
                             var searchValueConstant = Expression.Constant(globalSearchValue, typeof(string));
                             expression = (Expression<Func<TEntity, bool>>)Expression.Lambda(
                                 Expression.Invoke(expr, entityParam, searchValueConstant),
@@ -272,7 +271,7 @@ namespace DataTables.NetStandard.Extensions
                     if (searchPredicate != null)
                     {
                         var expr = searchPredicate;
-                        var entityParam = expr.Parameters.Single(p => p.Type == typeof(TEntity));
+                        var entityParam = ExpressionHelper.BuildParameterExpression<TEntity>();
                         var searchValueConstant = Expression.Constant(c.SearchValue, typeof(string));
                         expression = (Expression<Func<TEntity, bool>>)Expression.Lambda(
                             Expression.Invoke(expr, entityParam, searchValueConstant),

--- a/DataTables.NetStandard/Util/ExpressionHelper.cs
+++ b/DataTables.NetStandard/Util/ExpressionHelper.cs
@@ -33,9 +33,7 @@ namespace DataTables.NetStandard.Util
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
         internal static ParameterExpression BuildParameterExpression<TEntity>()
         {
-            var type = typeof(TEntity);
-
-            return Expression.Parameter(type);
+            return Expression.Parameter(typeof(TEntity));
         }
 
         /// <summary>


### PR DESCRIPTION
Due to EFCore 6 query caching, it does not work when using the same expression parameter instance multiple times. We therefore have to create a new expression parameter for every created lambda expression.