### PR TITLE
Fix memory issue with expression constants

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        dotnet-version: ['6.0.x']
+        dotnet-version: ['8.0.x']
 
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Build package
         run: dotnet build --configuration 'Release'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Build packages
         run: dotnet build --configuration 'Release'

--- a/DataTables.NetStandard.Sample/DataTables.NetStandard.Sample.csproj
+++ b/DataTables.NetStandard.Sample/DataTables.NetStandard.Sample.csproj
@@ -1,16 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <UserSecretsId>3635bc4d-44f6-4d28-930e-d7d3b2ea765e</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="DataTables.NetStandard.TemplateMapper" Version="1.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.16" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DataTables.NetStandard.Sample/DataTables/PersonDataTable.cs
+++ b/DataTables.NetStandard.Sample/DataTables/PersonDataTable.cs
@@ -28,9 +28,9 @@ namespace DataTables.NetStandard.Sample.DataTables
                     PrivatePropertyName = nameof(Person.Id),
                     IsOrderable = true,
                     IsSearchable = true,
-                    SearchPredicate = (p, s) => false,                  // The fallback predicate will never match, but since we declared a provider, it is not used anyway.
-                    SearchPredicateProvider = (s) => (p, s) => true,    // The provider will return a predicate matching all entities (used for global search). This is just for illustration, it makes no sense.
-                    ColumnSearchPredicateProvider = (s) =>              // The column provider will return a predicate matching entities in a numeric range if the search term is properly formatted.
+                    SearchPredicate = (p, s) => false,                 // The fallback predicate will never match, but since we declared a provider, it is not used anyway.
+                    //SearchPredicateProvider = (s) => (p, s) => true, // The provider will return a predicate matching all entities (used for global search). This is just for illustration, it makes no sense.
+                    ColumnSearchPredicateProvider = (s) =>             // The column provider will return a predicate matching entities in a numeric range if the search term is properly formatted.
                     {
                         var minMax = s.Split("-delim-", System.StringSplitOptions.RemoveEmptyEntries);
                         if (minMax.Length >= 2)

--- a/DataTables.NetStandard.Sample/Properties/launchSettings.json
+++ b/DataTables.NetStandard.Sample/Properties/launchSettings.json
@@ -1,12 +1,4 @@
-﻿{
-  "iisSettings": {
-    "windowsAuthentication": false, 
-    "anonymousAuthentication": true, 
-    "iisExpress": {
-      "applicationUrl": "http://localhost:53215",
-      "sslPort": 44331
-    }
-  },
+{
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
@@ -18,10 +10,28 @@
     "DataTables.NetStandard.Sample": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "applicationUrl": "https://localhost:5003;http://localhost:5002"
+    },
+    "WSL": {
+      "commandName": "WSL2",
+      "launchBrowser": true,
+      "launchUrl": "https://localhost:5001",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "https://localhost:5003;http://localhost:5002"
+      },
+      "distributionName": ""
+    }
+  },
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:53215",
+      "sslPort": 44331
     }
   }
 }

--- a/DataTables.NetStandard/DataTables.NetStandard.csproj
+++ b/DataTables.NetStandard/DataTables.NetStandard.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>3.0.1</Version>
-    <AssemblyVersion>3.0.1.0</AssemblyVersion>
-    <FileVersion>3.0.1.0</FileVersion>
+    <Version>3.0.2</Version>
+    <AssemblyVersion>3.0.2.0</AssemblyVersion>
+    <FileVersion>3.0.2.0</FileVersion>
     <Authors>Namoshek (Marvin Mall)</Authors>
     <Company>Namoshek (Marvin Mall)</Company>
     <PackageId>DataTables.NetStandard</PackageId>

--- a/DataTables.NetStandard/DataTablesRequest.cs
+++ b/DataTables.NetStandard/DataTablesRequest.cs
@@ -51,13 +51,13 @@ namespace DataTables.NetStandard
 
         /// <summary>
         /// Collection of DataTables column info.
-        /// Each column can be acessed via indexer by corresponding property name or by property selector. 
+        /// Each column can be acessed via indexer by corresponding property name or by property selector.
         /// </summary>
         /// <example>
         /// Example for an entity Student that has public property FirstName.
         /// <code>
         /// // Get DataTables request from Http query parameters
-        /// var request = new DataTablesRequest&lt;Student&gt;(url); 
+        /// var request = new DataTablesRequest&lt;Student&gt;(url);
         /// 
         /// // Access by property name
         /// var column = request.Columns["FirstName"];
@@ -70,7 +70,7 @@ namespace DataTables.NetStandard
             new List<DataTablesColumn<TEntity, TEntityViewModel>>();
 
         /// <summary>
-        /// Set this property to log incoming request parameters and resulting queries to the given delegate. 
+        /// Set this property to log incoming request parameters and resulting queries to the given delegate.
         /// For example, to log to the console, set this property to <see cref="Console.Write(string)"/>.
         /// </summary>
         public Action<string> Log { get; set; }
@@ -194,7 +194,7 @@ namespace DataTables.NetStandard
         {
             int start = int.TryParse(query["start"], out start) ? start : 0;
             PageSize = int.TryParse(query["length"], out int length) ? length : 15;
-            PageNumber = start / PageSize + 1;
+            PageNumber = (start / PageSize) + 1;
 
             Draw = int.TryParse(query["draw"], out int draw) ? draw : 0;
 

--- a/DataTables.NetStandard/Extensions/QueryableExtensions.cs
+++ b/DataTables.NetStandard/Extensions/QueryableExtensions.cs
@@ -200,7 +200,7 @@ namespace DataTables.NetStandard.Extensions
                         {
                             var expr = searchPredicate;
                             var entityParam = ExpressionHelper.BuildParameterExpression<TEntity>();
-                            var searchValueConstant = Expression.Constant(globalSearchValue, typeof(string));
+                            var searchValueConstant = ExpressionHelper.CreateConstantFilterExpression(globalSearchValue, typeof(string));
                             expression = (Expression<Func<TEntity, bool>>)Expression.Lambda(
                                 Expression.Invoke(expr, entityParam, searchValueConstant),
                                 entityParam);
@@ -233,7 +233,7 @@ namespace DataTables.NetStandard.Extensions
         }
 
         /// <summary>
-        /// Applies the search filter for each of the searchable <see cref="DataTablesRequest{TEntity, TEntityViewModel}.Columns"/> 
+        /// Applies the search filter for each of the searchable <see cref="DataTablesRequest{TEntity, TEntityViewModel}.Columns"/>
         /// where a search value is present.
         /// </summary>
         /// <typeparam name="TEntity">The type of the entity.</typeparam>
@@ -272,7 +272,7 @@ namespace DataTables.NetStandard.Extensions
                     {
                         var expr = searchPredicate;
                         var entityParam = ExpressionHelper.BuildParameterExpression<TEntity>();
-                        var searchValueConstant = Expression.Constant(c.SearchValue, typeof(string));
+                        var searchValueConstant = ExpressionHelper.CreateConstantFilterExpression(c.SearchValue, typeof(string));
                         expression = (Expression<Func<TEntity, bool>>)Expression.Lambda(
                             Expression.Invoke(expr, entityParam, searchValueConstant),
                             entityParam);


### PR DESCRIPTION
There is a problem using EFCore with `Expression.Constant`. Constants will be cached by EFCore and this slowly increase the used memory. Using `Expression.Constant(null, typeof(string));` for example shouldn't be a problem, because this value can be cached. But searching for values in the global/column search shouldn't be cached, because those values are dynamic. Therefore, this PR changes the dynamic search values to be based on expression bodies which are not cached by EFCore.